### PR TITLE
feat: `add`, `remove`, `list`, and `check` subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -723,6 +723,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "yansi",
 ]
 
 [[package]]
@@ -1615,6 +1616,12 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ etcetera = "0.8.0"
 reqwest = { version = "0.12.5", features = ["blocking", "json"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"
+yansi = { version = "1.0.1", features = ["hyperlink"] }
 
 [lints.clippy]
 all = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@ pub fn fetch_nixpkgs_pull_request(pull_request: u64, token: Option<&str>) -> Res
 	let url = format!("{}/pulls/{}", BASE_API_URL, pull_request);
 	let response = build_request(&url, token)
 		.send()?
+		.error_for_status()?
 		.json::<PullRequest>()?;
+
 	Ok(response)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,15 +72,15 @@ fn check(pull_request: u64, token: Option<&str>) -> Result<()> {
 			.link(pull_request.html_url)
 	);
 
-	let created_at_ago = format_seconds_to_time_ago(
-		Utc::now()
-			.signed_duration_since(pull_request.created_at)
-			.num_seconds()
-			.try_into()?,
-	);
-	let created_at_date = pull_request.created_at.to_rfc3339();
-
 	if pull_request.merged == false {
+		let created_at_ago = format_seconds_to_time_ago(
+			Utc::now()
+				.signed_duration_since(pull_request.created_at)
+				.num_seconds()
+				.try_into()?,
+		);
+		let created_at_date = pull_request.created_at.to_rfc3339();
+
 		println!("This pull request hasn't been merged yet!");
 		println!("Created {} ago ({}).", created_at_ago, created_at_date);
 	} else {
@@ -94,8 +94,16 @@ fn check(pull_request: u64, token: Option<&str>) -> Result<()> {
 			.merged_at
 			.unwrap()
 			.to_rfc3339();
+		let creation_to_merge_time = format_seconds_to_time_ago(
+			pull_request
+				.merged_at
+				.unwrap()
+				.signed_duration_since(pull_request.created_at)
+				.num_seconds()
+				.try_into()?,
+		);
 
-		println!("Merged {} ago ({}), {} after creation ({}).", merged_at_ago, merged_at_date, created_at_ago, created_at_date);
+		println!("Merged {} ago ({}), {} after creation.", merged_at_ago, merged_at_date, creation_to_merge_time);
 
 		for branch in DEFAULT_BRANCHES {
 			let has_pull_request = branch_contains_commit(branch, &commit_sha, token)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,8 @@ fn check(pull_request: u64, token: Option<&str>) -> Result<()> {
 	};
 
 	println!(
-		"{}",
+		"[{}] {}",
+		pull_request.number,
 		pull_request
 			.title
 			.link(pull_request.html_url)

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,9 +171,15 @@ fn main() -> Result<()> {
 			)
 		}
 		Some(Commands::Check {}) => {
-			for pull_request in &cache_data.pull_requests {
+			for (i, pull_request) in cache_data
+				.pull_requests
+				.iter()
+				.enumerate()
+			{
 				check(*pull_request, args.token.as_deref())?;
-				println!("---")
+				if i != (cache_data.pull_requests.len() - 1) {
+					println!();
+				}
 			}
 		}
 		None => check(args.pull_request.expect("is present"), args.token.as_deref())?,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,59 +1,185 @@
-use clap::Parser;
+use std::fs;
+
+use clap::{Parser, Subcommand};
 use color_eyre::eyre::{Ok, Result};
+use serde::{Deserialize, Serialize};
 
 use chrono::Utc;
+use etcetera::{choose_base_strategy, BaseStrategy};
 use nixpkgs_track::{branch_contains_commit, fetch_nixpkgs_pull_request, utils::format_seconds_to_time_ago};
+use yansi::hyperlink::HyperlinkExt;
+
+static DEFAULT_BRANCHES: [&str; 6] = ["master", "staging", "staging-next", "nixpkgs-unstable", "nixos-unstable-small", "nixos-unstable"];
 
 #[derive(Parser)]
-#[command(version, about)]
+#[command(version, about, subcommand_negates_reqs = true)]
 struct Cli {
-	pull_request: u64,
+	#[clap(required(true))]
+	pull_request: Option<u64>,
+
+	#[command(subcommand)]
+	command: Option<Commands>,
 
 	/// GitHub token
 	#[clap(long, short, env = "GITHUB_TOKEN")]
 	token: Option<String>,
 }
 
-fn main() -> Result<()> {
-	let args = Cli::parse();
-	color_eyre::install()?;
+#[derive(Subcommand)]
+enum Commands {
+	/// Add a pull request to tracking list
+	Add { pull_request: u64 },
+	/// Remove a pull request from the tracking list
+	Remove {
+		pull_request: u64,
 
-	println!("Fetching pull request data...");
-	let pull_request = fetch_nixpkgs_pull_request(args.pull_request, args.token.as_deref())?;
+		#[clap(long)]
+		all: bool,
+	},
+	/// List tracked pull requests
+	List {
+		#[clap(long)]
+		json: bool,
+	},
+	/// Recheck tracked pull requests
+	Check {},
+}
+
+#[derive(Serialize, Deserialize)]
+struct Cache {
+	pull_requests: Vec<u64>,
+}
+
+impl Cache {
+	fn new() -> Self {
+		return Cache { pull_requests: vec![] };
+	}
+}
+
+fn check(pull_request: u64, token: Option<&str>) -> Result<()> {
+	let pull_request = fetch_nixpkgs_pull_request(pull_request, token)?;
 
 	let Some(commit_sha) = pull_request.merge_commit_sha else {
 		println!("This pull request is very old. I can't track it!");
 		return Ok(());
 	};
 
+	println!(
+		"{}",
+		pull_request
+			.title
+			.link(pull_request.html_url)
+	);
+
+	let created_at_ago = format_seconds_to_time_ago(
+		Utc::now()
+			.signed_duration_since(pull_request.created_at)
+			.num_seconds()
+			.try_into()?,
+	);
+	let created_at_date = pull_request.created_at.to_rfc3339();
+
 	if pull_request.merged == false {
-		println!("This pull request hasn't been merged yet!")
+		println!("This pull request hasn't been merged yet!");
+		println!("Created {} ago ({}).", created_at_ago, created_at_date);
 	} else {
-		println!("{} ({})", pull_request.title, pull_request.html_url);
-		println!(
-			"Merged {} ago ({}).",
-			format_seconds_to_time_ago(
-				Utc::now()
-					.signed_duration_since(pull_request.merged_at.unwrap())
-					.num_seconds()
-					.try_into()?
-			),
-			pull_request
-				.merged_at
-				.unwrap()
-				.to_rfc3339()
+		let merged_at_ago = format_seconds_to_time_ago(
+			Utc::now()
+				.signed_duration_since(pull_request.merged_at.unwrap())
+				.num_seconds()
+				.try_into()?,
 		);
+		let merged_at_date = pull_request
+			.merged_at
+			.unwrap()
+			.to_rfc3339();
 
-		println!("Fetching branch comparisons...");
+		println!("Merged {} ago ({}), {} after creation ({}).", merged_at_ago, merged_at_date, created_at_ago, created_at_date);
 
-		let branches = ["master", "staging", "staging-next", "nixpkgs-unstable", "nixos-unstable-small", "nixos-unstable"];
-
-		for branch in branches {
-			let has_pull_request = branch_contains_commit(branch, &commit_sha, args.token.as_deref())?;
+		for branch in DEFAULT_BRANCHES {
+			let has_pull_request = branch_contains_commit(branch, &commit_sha, token)?;
 
 			println!("{}: {}", branch, if has_pull_request { "✅" } else { "🚫" });
 		}
 	}
+
+	Ok(())
+}
+
+fn main() -> Result<()> {
+	let args = Cli::parse();
+	color_eyre::install()?;
+
+	let cache_dir = choose_base_strategy()?
+		.cache_dir()
+		.join("nixpkgs-track");
+	if !cache_dir.exists() {
+		fs::create_dir_all(&cache_dir)?;
+	}
+
+	let cache = cache_dir.join("cache.json");
+
+	let mut cache_data: Cache = if cache.exists() { serde_json::from_str(&fs::read_to_string(&cache)?)? } else { Cache::new() };
+
+	match args.command {
+		Some(Commands::Add { pull_request }) => cache_data
+			.pull_requests
+			.push(pull_request),
+		Some(Commands::Remove { pull_request, all }) => {
+			if all {
+				cache_data.pull_requests.clear();
+			} else {
+				cache_data.pull_requests = cache_data
+					.pull_requests
+					.into_iter()
+					.filter(|&x| x != pull_request)
+					.collect()
+			}
+		}
+		Some(Commands::List { json }) => {
+			#[derive(Serialize, Deserialize)]
+			struct TrackedPullRequest {
+				id: u64,
+				title: String,
+				url: String,
+			}
+			let pull_requests = cache_data
+				.pull_requests
+				.iter()
+				.map(|&pr| {
+					let data = fetch_nixpkgs_pull_request(pr, args.token.as_deref())?;
+
+					Ok(TrackedPullRequest {
+						id: pr,
+						title: data.title,
+						url: data.html_url,
+					})
+				})
+				.collect::<Result<Vec<_>, _>>()?;
+
+			println!(
+				"{}",
+				if json {
+					serde_json::to_string(&pull_requests)?
+				} else {
+					pull_requests
+						.iter()
+						.map(|tpr| format!("[{}] {}", &tpr.id, &tpr.title.link(&tpr.url)))
+						.collect::<Vec<_>>()
+						.join("\n")
+				}
+			)
+		}
+		Some(Commands::Check {}) => {
+			for pull_request in &cache_data.pull_requests {
+				check(*pull_request, args.token.as_deref())?;
+				println!("---")
+			}
+		}
+		None => check(args.pull_request.expect("is present"), args.token.as_deref())?,
+	}
+
+	fs::write(&cache, serde_json::to_string(&cache_data)?)?;
 
 	Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,11 @@ fn main() -> Result<()> {
 			}
 		}
 		Some(Commands::List { json }) => {
+			if cache_data.pull_requests.len() == 0 {
+				println!("No pull requests saved.");
+				return Ok(());
+			}
+
 			#[derive(Serialize, Deserialize)]
 			struct TrackedPullRequest {
 				id: u64,
@@ -184,6 +189,11 @@ fn main() -> Result<()> {
 			)
 		}
 		Some(Commands::Check {}) => {
+			if cache_data.pull_requests.len() == 0 {
+				println!("No pull requests saved.");
+				return Ok(());
+			}
+
 			for (i, pull_request) in cache_data
 				.pull_requests
 				.iter()


### PR DESCRIPTION
Allows tracking multiple PRs at once - use `nixpkgs-track add xyz` to add the xyz pull request to the tracker. Running `nixpkgs-track check` will check against all tracked pull requests, `nixpkgs-track list` can be used to list them and `nixpkgs-track remove` to remove one/all.