### PR TITLE
performance improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ use serde::Deserialize;
 
 const BASE_API_URL: &str = "https://api.github.com/repos/nixos/nixpkgs";
 
-fn build_request(url: &str, token: Option<&str>) -> RequestBuilder {
-	let mut request = Client::new()
+fn build_request(client: impl AsRef<reqwest::Client>, url: &str, token: Option<&str>) -> RequestBuilder {
+	let mut request = client.as_ref()
 		.get(url)
 		.header("User-Agent", "nixpkgs-track");
 
@@ -19,9 +19,9 @@ fn build_request(url: &str, token: Option<&str>) -> RequestBuilder {
 	request
 }
 
-pub async fn fetch_nixpkgs_pull_request(pull_request: u64, token: Option<&str>) -> Result<PullRequest> {
+pub async fn fetch_nixpkgs_pull_request(client:  impl AsRef<reqwest::Client>, pull_request: u64, token: Option<&str>) -> Result<PullRequest> {
 	let url = format!("{}/pulls/{}", BASE_API_URL, pull_request);
-	let response = build_request(&url, token)
+	let response = build_request(client, &url, token)
 		.send()
 		.await?
 		.error_for_status()?
@@ -31,10 +31,10 @@ pub async fn fetch_nixpkgs_pull_request(pull_request: u64, token: Option<&str>) 
 	Ok(response)
 }
 
-pub async fn branch_contains_commit(branch: &str, commit: &str, token: Option<&str>) -> Result<bool> {
+pub async fn branch_contains_commit(client:  impl AsRef<reqwest::Client>, branch: &str, commit: &str, token: Option<&str>) -> Result<bool> {
 	let url = format!("{}/compare/{}...{}", BASE_API_URL, branch, commit);
 
-	let response = build_request(&url, token)
+	let response = build_request(client,&url, token)
 		.send()
 		.await?;
 	Ok(match response.status() {


### PR DESCRIPTION
Can pick and choose changes from this, but the important one is avoiding creating additional reqwest clients, because this is slow AF.

Here's the flamegraph after a few other modifications (mostly in service of further parallelism and also writing to a string buffer and then printing it at the end so as to keep things ordered correctly) but creating clients per check task.

![flame1](https://github.com/user-attachments/assets/7d3525eb-ef42-4440-9ac4-8fd3caa97aec)

And after moving to only creating a single reqwest Client and passing around an Arc of it.

![flame2](https://github.com/user-attachments/assets/d09c84b6-4472-4eae-933e-ef641f0cc678)

The latter is almost 10x shorter in terms of samples on the graph, which roughly correlate to execution time, and is noticeably faster to run.