### PR TITLE
fix: add default package defn to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         naersk' = pkgs.callPackage naersk { };
       in
       {
-        packages = {
+        packages = rec {
           nixpkgs-track = naersk'.buildPackage {
             pname = "nixpkgs-track";
             src = ./.;
@@ -33,6 +33,7 @@
               openssl
             ];
           };
+          default = nixpkgs-track;
         };
 
         devShell = pkgs.mkShell {


### PR DESCRIPTION
Without this `nix run github:uncenter/nixpkgs-track` has to be accompanied with
a trailing `#nixpkgs-track`.

PS: I use a default overlay to make my projects easier to install, I also
[included][2] that in my fork, inspired by [papis-nvim][1]. If it sounds
interesting I can open another PR for that as well.

[1]: https://github.com/jghauser/papis.nvim/blob/68457df80b1330be656984e81d21755cfbd6952b/README.md#nix
[2]: https://github.com/uncenter/nixpkgs-track/commit/b1b706eaf3acab37085fe6b2b779ee929523cb5b
