### PR TITLE
 feat: support tracking stable branches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -903,6 +903,7 @@ dependencies = [
  "env_logger",
  "miette",
  "nixpkgs-track_lib",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/nixpkgs-track/Cargo.toml
+++ b/crates/nixpkgs-track/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "2.0.11"
 env_logger = "0.11.6"
 user_dirs = "0.2.0"
 dialoguer = "0.11.0"
+regex = "1.11.1"
 
 [lints]
 workspace = true

--- a/crates/nixpkgs-track/src/main.rs
+++ b/crates/nixpkgs-track/src/main.rs
@@ -97,7 +97,10 @@ async fn check(client: Arc<reqwest::Client>, pull_request: u64, token: Option<&s
 		);
 		let merged_into_branch = pull_request.base.r#ref;
 
-		writeln!(output, "Merged {merged_at_ago} ago ({merged_at_date}), {creation_to_merge_time} after creation, into branch '{merged_into_branch}'.")?;
+		writeln!(
+			output,
+			"Merged {merged_at_ago} ago ({merged_at_date}), {creation_to_merge_time} after creation, into branch '{merged_into_branch}'."
+		)?;
 
 		let stable_branches: Option<Vec<String>> = if ROLLING_BRANCHES.contains(&merged_into_branch.as_str()) {
 			None
@@ -117,7 +120,10 @@ async fn check(client: Arc<reqwest::Client>, pull_request: u64, token: Option<&s
 
 		#[allow(clippy::redundant_closure_for_method_calls)]
 		let tracked_branches = match stable_branches {
-			Some(ref stable_branches) => stable_branches.iter().map(|s| s.as_str()).collect(),
+			Some(ref stable_branches) => stable_branches
+				.iter()
+				.map(|s| s.as_str())
+				.collect(),
 			None => Vec::from(ROLLING_BRANCHES),
 		};
 

--- a/crates/nixpkgs-track_lib/src/lib.rs
+++ b/crates/nixpkgs-track_lib/src/lib.rs
@@ -42,7 +42,10 @@ pub async fn fetch_nixpkgs_pull_request(client: impl AsRef<reqwest::Client>, pul
 }
 
 pub async fn branch_contains_commit(client: impl AsRef<reqwest::Client>, branch: &str, commit: &str, token: Option<&str>) -> Result<bool, NixpkgsTrackError> {
-	let url = format!("{BASE_API_URL}/compare/{branch}...{commit}");
+	// `per_page=1000000&page=100`: a hack for the API, to _not_ return
+	//   information about files or commits, which we do not need here;
+    //   we only need to know whether it's `ahead` or `behind`
+	let url = format!("{BASE_API_URL}/compare/{branch}...{commit}?per_page=1000000&page=100");
 	let response = build_request(client, &url, token)
 		.send()
 		.await;

--- a/crates/nixpkgs-track_lib/src/lib.rs
+++ b/crates/nixpkgs-track_lib/src/lib.rs
@@ -72,6 +72,7 @@ pub struct User {
 	pub url: String,
 }
 
+#[non_exhaustive]
 #[derive(Clone, Debug, Deserialize)]
 pub struct PullRequest {
 	pub html_url: String,
@@ -82,6 +83,20 @@ pub struct PullRequest {
 	pub merged_at: Option<DateTime<Utc>>,
 	pub merged: bool,
 	pub merge_commit_sha: Option<String>,
+	/// Base branch that the pull request is merged into
+	pub base: ForkBranch,
+	/// Head branch that the pull request is merged from
+	pub head: ForkBranch,
+}
+
+#[non_exhaustive]
+#[derive(Clone, Debug, Deserialize)]
+pub struct ForkBranch {
+	/// Fork and branch name in the format "owner:branch"
+	pub label: String,
+	/// Branch name in a given fork
+	pub r#ref: String,
+	pub sha: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/crates/nixpkgs-track_lib/src/lib.rs
+++ b/crates/nixpkgs-track_lib/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn fetch_nixpkgs_pull_request(client: impl AsRef<reqwest::Client>, pul
 pub async fn branch_contains_commit(client: impl AsRef<reqwest::Client>, branch: &str, commit: &str, token: Option<&str>) -> Result<bool, NixpkgsTrackError> {
 	// `per_page=1000000&page=100`: a hack for the API, to _not_ return
 	//   information about files or commits, which we do not need here;
-    //   we only need to know whether it's `ahead` or `behind`
+	//   we only need to know whether it's `ahead` or `behind`
 	let url = format!("{BASE_API_URL}/compare/{branch}...{commit}?per_page=1000000&page=100");
 	let response = build_request(client, &url, token)
 		.send()


### PR DESCRIPTION
Closes #13.

This PR implements tracking for stable branches. It includes the following changes:
- Branches are slightly re-ordered (now it's staging > staging-next > master > ,,,) to better represent the staging workflow.
- PRs targeting the stable branches are now correctly tracked, including stable staging PRs like the one mentioned in #13.
- This is enabled by looking at the `head` and `base` fields of the API json responses, held in the `PullRequest` struct. Adding these fields is technically a breaking change for the lib crate, but really no one should be constructing these responses by hand and the fields are clearly non-exhaustive, so we take the chance to add the `#[non_exhaustive]` marker to the relevant structs.
- Along the way, we add some pagination parameters in the API url for it to return less irrelevant information. This is a hack which _may_ speed up the responses and its processing. This is the first commit and it's not exactly related to the others so it can be dropped independently if it feels too unnecessarily hacky.